### PR TITLE
Fix Ruby 3.3.8 compatibility and improve Zeitwerk support for non-Rails projects

### DIFF
--- a/lib/annotate_rb/eager_loader.rb
+++ b/lib/annotate_rb/eager_loader.rb
@@ -7,17 +7,16 @@ module AnnotateRb
       def call(options)
         options[:require].count > 0 && options[:require].each { |path| require path }
 
-        if defined?(::Rails::Application)
-          if defined?(::Zeitwerk)
-            # Delegate to Zeitwerk to load stuff as needed
-          else
-            klass = ::Rails::Application.send(:subclasses).first
-            klass.eager_load!
-          end
+        if defined?(::Zeitwerk)
+          # Delegate to Zeitwerk to load stuff as needed
+          #   (Supports both Rails and non-Rails applications)
+        elsif defined?(::Rails::Application)
+          klass = ::Rails::Application.send(:subclasses).first
+          klass.eager_load!
         else
           model_files = ModelAnnotator::ModelFilesGetter.call(options)
           model_files&.each do |model_file|
-            require model_file
+            require File.join(*model_file)
           end
         end
       end


### PR DESCRIPTION
## Problem

annotaterb 4.18.0 fails on Ruby 3.3.8 with a `TypeError: no implicit conversion of Array into String` when used in non-Rails ActiveRecord projects. Additionally, the current logic doesn't properly handle Zeitwerk in non-Rails frameworks.

**Stack trace:**
```
/ruby/3.3.0/bundled_gems.rb:124:in `path': no implicit conversion of Array into String (TypeError)
    feature = File.path(name)
                        ^^^^
	from /annotate_rb/eager_loader.rb:20:in `block in call'
```

## Root Cause

In `eager_loader.rb:20`, the code attempts to `require` elements returned by `ModelFilesGetter.call(options)`. 
However, `ModelFilesGetter` returns an array of `[directory, filename]` pairs (e.g., `[["app/models", "sms.rb"], ["app/models", "user.rb"]]`), not file paths.

The bug occurs because:
1. `EagerLoader` calls `require model_file` where `model_file` is `["app/models", "sms.rb"]`
2. Ruby's `require` internally calls `File.path()` on the argument
3. Ruby 3.3.8's stricter type checking in `bundled_gems.rb` rejects the Array

### Why This Wasn't Caught Earlier

- **Only affects non-Rails projects**: Rails projects use the `if defined?(::Rails::Application)` branch and skip this code path
- **Recent Ruby version**: Ruby 3.3.8's stricter bundled gem handling is relatively new
- **Limited use case**: Most annotaterb users are in Rails apps

## Solution

This PR addresses both the immediate bug and improves framework compatibility with two changes:

### 1. Fix Array→String Conversion Bug
Convert the `[directory, filename]` array to a proper file path using `File.join(*model_file)`:

```ruby
# Before (broken)
require model_file  # Tries to require ["app/models", "sms.rb"]

# After (fixed)  
require File.join(*model_file)  # Requires "app/models/sms.rb"
```

### 2. Improve Zeitwerk Support for Non-Rails Frameworks

Move the Zeitwerk check outside the Rails check to support modern non-Rails frameworks that use Zeitwerk (like Gruf, Hanami, etc.):

## Benefits

**For Ruby 3.3.8 users:**
- ✅ Resolves the TypeError that prevents annotaterb from working

**For non-Rails + Zeitwerk frameworks (Gruf, Hanami, etc.):**
- ✅ Eliminates Zeitwerk loader conflicts
- ✅ Uses proper lazy loading instead of eager loading all models
- ✅ Better performance for large codebases

**For all users:**
- ✅ More framework-agnostic design
- ✅ Maintains full backward compatibility

## Testing

Confirmed the fix resolves both the TypeError on Ruby 3.3.8 and Zeitwerk conflicts in a Gruf gRPC application using ActiveRecord.

## Backward Compatibility

Both changes are fully backward compatible:
- `File.join(*["dir", "file"])` produces the same result as the intended behavior on all Ruby versions
- Zeitwerk check prioritization doesn't affect existing Rails or non-Zeitwerk workflows
